### PR TITLE
Use `snapista` as a backend to use `SNAP`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ## Installation
 
 
-This project uses `SNAP`, you can download it [here](https://step.esa.int/main/download/snap-download/).
+This project uses [SNAP](https://step.esa.int/main/download/snap-download/), however its installation will be done automatically by conda. 
+To access `SNAP` through python, we use `snapista`, a conda package. 
+Unfortunately, very specific version of python packages are needed to install it. 
 
----
-Unfortunately, the interface between `SNAP` and python requires specifics version to work.
 To ease the installation, we provide an `yml` file for conda to create a clean environment.
 
 You can install it with:
@@ -20,29 +20,6 @@ Don't forget to activate the environment with:
 ```bash
 conda activate snap
 ```
----
-
-For the final step, you need to configure `snappy` and install it in your python environment.
-
-Read the complete [documentation](https://senbox.atlassian.net/wiki/spaces/SNAP/pages/50855941/Configure+Python+to+use+the+SNAP-Python+snappy+interface) for more information, but basically you need to execute:
-```bash
-cd <snap-install-dir>/bin
-./snappy-conf <conda-install-dir>/envs/snap/bin/python3
-```
-Now that snappy is configured, you can import it manually everytime or install it with:
-```bash
-cd <snappy-dir>/bin
-python3 setup.py install
-```
-
-Defaults locations are:
-
-| Location           | Default path              |
-|--------------------|---------------------------|
-| snap-install-dir   | ~ (home directory)        |
-| conda-install-dir  | ~/{Ana,mini}conda3/       |
-| snappy-dir         | .snap/snap-python/snappy/ |
-
 
 ## Authentication
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,9 @@
 name: snap
 channels:
   - defaults
+  - terradue
+  - conda-forge
 dependencies:
-  - geopandas
-  - python=3.6
-  - shapely
-  - tqdm
-  - matplotlib
-  - numpy
+  - snapista
   - flake8
   - black


### PR DESCRIPTION
While leaving some customisation on the table, using `snapista` instead of `snappy` gives us access to multiprocessing. Indeed, the former create a `XML` graph and process it using `gpt`, the command line interface of `SNAP`. And as a consequence, moving out of reach of the `GIL`, which prevented us from getting decent multiprocessing performances.

This patch unfortunately drops some feature of `main.py` but they were mainly useful for development purpose. We don't need them to execute this on a server.

It also simplifies the installation process as we are now installing `SNAP` as a conda package. It also gets us rid of the complex configuration of `snappy`.