### PR TITLE
Return early if the requested polygon is empty

### DIFF
--- a/server/sentinel_extractor.py
+++ b/server/sentinel_extractor.py
@@ -43,6 +43,9 @@ def download_sentinel_data(
 
     assert start_date <= end_date
 
+    if len(request_geojson["features"]) == 0:
+        return None
+
     api = SentinelAPI(None, None)
     footprint = geojson_to_wkt(request_geojson)
 


### PR DESCRIPTION
Requesting an empty polygon used to cause an internal error. This is now smoothly handled.