### PR TITLE
Change the shorelineExtension parameter from 0 to 20

### DIFF
--- a/server/ship_detection.py
+++ b/server/ship_detection.py
@@ -39,7 +39,7 @@ def add_land_sea_mask(graph_l: Graph):
             landMask="true",
             useSRTM="true",
             invertGeometry="false",
-            shorelineExtension=10,
+            shorelineExtension="20",
         ),
         node_id="land_sea_mask",
         source="read",


### PR DESCRIPTION
`snapista` only accept string values so 10 wasn't considered and the default value was used.

On a tile covering Rotterdam and Amsterdam, it achieves to remove around 218 detections.

This parameter unfortunately has a performance substantial impact, around two minutes on my PC.

Before:

![Before](https://user-images.githubusercontent.com/26030965/213953305-b337c319-ec7f-42e2-b000-5dfdeaaf2f64.png)


After:

![After](https://user-images.githubusercontent.com/26030965/213953325-27c96842-04f9-43b8-ace8-e1e99e0902e6.png)



On the actual generated LandMask:
With shorelineExtension=0, generated in 22s:
![mask_0](https://user-images.githubusercontent.com/26030965/213953771-8037aac6-9b3c-47bf-a882-aee1e343b28a.png)


With shorelineExtension=20, generated in 170s:
![mask_20](https://user-images.githubusercontent.com/26030965/213954242-5a1c1998-6c16-4f24-83be-9cde5dc2135c.png)
