### PR TITLE
Add a function to remove duplicates detections from the database

### DIFF
--- a/Server/main.py
+++ b/Server/main.py
@@ -96,6 +96,8 @@ def detect_ships_in_area(geo_dict: FeatureCollection):
         session.add(db_result)
         session.commit()
 
+    crud.remove_duplicates(session)
+
 
 @app.get("/ships.geojson")
 def get_ships(


### PR DESCRIPTION
The CFAR algorithm often generates duplicates. The new function remove detections with matching position.

On a tile covering Rotterdam and Amsterdam, it achieves to remove 20 detections.

yay
![worried_264](https://user-images.githubusercontent.com/26030965/213960431-fdf75bfe-93cc-436e-9008-d5f76680306d.png)
![safe_264](https://user-images.githubusercontent.com/26030965/213960452-48845f04-eea1-4e64-8596-ca80d2297fe4.png)


