### PR TITLE
Use OpenStreetMap as a source for the land-sea-mask

### DIFF
--- a/server/ship_detection.py
+++ b/server/ship_detection.py
@@ -32,17 +32,28 @@ def add_write_node(graph_l: Graph, output_filename: Path):
     )
 
 
+def add_land_mask_vector(graph_l: Graph, vector_file: Path):
+    graph_l.add_node(
+        operator=Operator(
+            "Import-Vector", vectorFile=str(vector_file), separateShapes="false"
+        ),
+        node_id="import-vector",
+        source="read",
+    )
+
+
 def add_land_sea_mask(graph_l: Graph):
     graph_l.add_node(
         operator=Operator(
             "Land-Sea-Mask",
-            landMask="true",
-            useSRTM="true",
-            invertGeometry="false",
-            shorelineExtension=10,
+            landMask="false",
+            useSRTM="false",
+            geometry="land_polygons",
+            invertGeometry="true",
+            shorelineExtension="0",  # Unfortunately, this parameter can't be used in combination with geometry
         ),
         node_id="land_sea_mask",
-        source="read",
+        source="import-vector",
     )
 
 
@@ -92,6 +103,7 @@ def add_object_discrimination(graph_l: Graph):
 
 
 def add_preprocessing(graph_l: Graph):
+    add_land_mask_vector(graph_l, Path("land-polygons-complete-4326/land_polygons.shp"))
     add_land_sea_mask(graph_l)
     add_calibration(graph_l)
     add_adaptive_thresholding(graph_l)


### PR DESCRIPTION
This is an alternative solution to the issue #29 tries to solve, only one of both solution should be merged.

It is a draft for now, as we should retrieve the source file automatically and not hardcode the path.

The mask comes from OpenStreetMap is much more accurate than SRTM. But, when using another source, the Land-Sea-Mask operator does not consider shorelineExtension. Which mean that we are stuck with any issue that the new mask has.

On the same tile as #29, the number of detection drops to 490 (330 fewer detections):
![osm](https://user-images.githubusercontent.com/26030965/213969755-7aeb25a5-4bb6-4d92-a0f4-4c0e0d74aae9.png)

The mask:
![mask](https://user-images.githubusercontent.com/26030965/213969791-b63a4506-66b6-4209-a7bd-2ab3bad83bd8.png)
