### PR TITLE
Remove realtime from imported plugins in html

### DIFF
--- a/GIS/index.html
+++ b/GIS/index.html
@@ -39,8 +39,6 @@
     />
     <script src="node_modules/markercluster/dist/leaflet.markercluster.js"></script>
 
-    <script src="node_modules/realtime/dist/leaflet-realtime.js"></script>
-
     <script src="node_modules/boatmarker/leaflet.boatmarker.min.js"></script>
 
     <link


### PR DESCRIPTION
This should have been done in 8f82164e37105a6c05264bc989db298e88c44e67.