### PR TITLE
Block all clients on a call to "/polygon"

### DIFF
--- a/GIS/app.js
+++ b/GIS/app.js
@@ -280,8 +280,13 @@ const ws_data_server_url =
 const ws = new WebSocket(ws_data_server_url + ws_client_id);
 
 ws.onmessage = function (event) {
-  if (event.data === "success") {
+  if (event.data === "unblock") {
     setButtonState(true);
+    return;
+  }
+
+  if (event.data === "block") {
+    setButtonState(false);
     return;
   }
 


### PR DESCRIPTION
It also fixes an error when we were calling `socket.send_text()` in `broadcast()` without `await`ing it. The fix is only a workaround, a better solution probably exists.